### PR TITLE
Minimal import export int

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-waffle-session',
-    version='0.2.2',
+    version='0.2.3',
     description='A feature flipper for Django.',
     long_description=open('README.rst').read(),
     author='Francis Mwangi',

--- a/travis.txt
+++ b/travis.txt
@@ -5,4 +5,3 @@ Jinja2>=2.7.1
 jingo==0.7
 South==0.8.3
 django-discover-runner==1.0
-django-import-export==0.6.1

--- a/travis.txt
+++ b/travis.txt
@@ -5,3 +5,4 @@ Jinja2>=2.7.1
 jingo==0.7
 South==0.8.3
 django-discover-runner==1.0
+django-import-export==0.6.1

--- a/travis.txt
+++ b/travis.txt
@@ -5,4 +5,4 @@ Jinja2>=2.7.1
 jingo==0.7
 South==0.8.3
 django-discover-runner==1.0
-#django-import-export==0.6.1
+django-import-export==0.6.1

--- a/travis.txt
+++ b/travis.txt
@@ -5,4 +5,4 @@ Jinja2>=2.7.1
 jingo==0.7
 South==0.8.3
 django-discover-runner==1.0
-django-import-export==0.6.1
+#django-import-export==0.6.1

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-
+from import_export.admin import ImportExportModelAdmin
+from resources import VerifiedUserResource
 from waffle.models import Flag, Sample, Switch, VerifiedUser
 
 
@@ -28,10 +29,11 @@ class FlagAdmin(admin.ModelAdmin):
     raw_id_fields = ('users', 'groups')
     ordering = ('-id',)
 
-class VerifiedUserAdmin(admin.ModelAdmin):
+class VerifiedUserAdmin(ImportExportModelAdmin):
     list_display = ('phone_number', 'feature')
     list_filter = ('feature', )
     search_fields = ('phone_number', )
+    resource_class = VerifiedUserResource
 
 
 

--- a/waffle/resources.py
+++ b/waffle/resources.py
@@ -1,0 +1,12 @@
+from import_export import resources
+from waffle.models import VerifiedUser
+
+
+class VerifiedUserResource(resources.ModelResource):
+    class Meta:
+        model = VerifiedUser
+        # Exclude verified user and feature_id. Feature returns id
+        exclude = ('id', 'feature_id')
+        import_id_fields = ('feature', 'phone_number', 'feature__name')
+        fields = ('feature', 'phone_number', 'feature__name')
+        export_order = ('feature', 'phone_number', 'feature__name')


### PR DESCRIPTION
Extend django-waffle-session by integrating with django-import-export to allow bulk import and exports of users during whitelisting. Multiple formats are supported.

The build is not passing on circle CI because a lot of work which is out of scope needs to go into this repo so that it meets the standards of the other repos. Separate cards will be created for those points.